### PR TITLE
Add old data to the DELETE notification

### DIFF
--- a/resources/migrations/20161105154847-events-table.up.sql
+++ b/resources/migrations/20161105154847-events-table.up.sql
@@ -21,6 +21,8 @@ BEGIN
    || TG_TABLE_NAME
    || ', '''
    || TG_OP
+   || ' '
+   || OLD
    || '''';
  END IF;
  return new;


### PR DESCRIPTION
This why we can remove data on the Frontend.
Otherwise the notification contains only the DELETE string.